### PR TITLE
Experiment1 ap reconnection

### DIFF
--- a/RateMan/rateman/core.py
+++ b/RateMan/rateman/core.py
@@ -36,6 +36,9 @@ __all__ = [
     "connect_to_AP",
     "timer",
     "stop_rateman",
+    "check_APs_connection",
+    "reconnect_to_AP",
+    "restart_radios"
 ]
 
 


### PR DESCRIPTION
Added reconnection feature for APs that disconnect while fetching data.
Made documentation more specific.
Added a new key called 'conn' for APInfo dictionary which indicate whether the connection to this AP is active or not.
Inactive APs no longer get deleted from the APInfo dictionary.
