### PR TITLE
Extended parsing and minor changes

### DIFF
--- a/RateMan/rateman/parsing.py
+++ b/RateMan/rateman/parsing.py
@@ -94,7 +94,7 @@ def process_line(ap, line):
         process_api(ap, fields)
         return None
 
-    if len(fields) == 3:
+    if len(fields) == 4:
         if fields[1] == "0" and fields[2] == "add":
             if "phy" in fields[0]:
                 ap.add_phy(fields[0])
@@ -260,6 +260,12 @@ def update_pckt_count_txs(ap, fields):
 
     sta.update_stats(timestamp, info)
 
+    if num_frames > 1:
+        sta.ampdu_enabled = True
+    
+    sta.ampdu_len += num_frames
+    sta.ampdu_packets += 1
+
 
 def update_pckt_count_rcs(ap, fields):
     # TODO: what about this?
@@ -289,6 +295,8 @@ def update_pckt_count_rcs(ap, fields):
 def parse_sta(ap, fields):
     supp_rates = []
     mcs_groups = fields[7:]
+    overhead_mcs = int(fields[5], 16)
+    overhead_legacy = int(fields[6], 16)
 
     for i, group_idx in enumerate(ap.supp_rates):
         mask = int(mcs_groups[i], 16)
@@ -296,6 +304,6 @@ def parse_sta(ap, fields):
             if mask & (1 << j):
                 supp_rates.append(f"{group_idx}{j}")
         
-    sta = Station(fields[0], fields[4], supp_rates, fields[1])
+    sta = Station(fields[0], fields[4], supp_rates, fields[1], overhead_mcs, overhead_legacy)
 
     return sta

--- a/RateMan/rateman/rateman.py
+++ b/RateMan/rateman/rateman.py
@@ -141,6 +141,9 @@ class RateMan:
 
         """
         entry_func = None
+
+        if rate_control_algorithm == "minstrel_ht_kernel_space":
+            return
         
         try:
             entry_func = importlib.import_module(rate_control_algorithm).start

--- a/RateMan/rateman/station.py
+++ b/RateMan/rateman/station.py
@@ -16,7 +16,7 @@ __all__ = ["Station"]
 
 
 class Station:
-    def __init__(self, radio, mac_addr, supp_rates, timestamp) -> None:
+    def __init__(self, radio, mac_addr, supp_rates, timestamp, overhead_mcs, overhead_legacy) -> None:
         """
         Parameters
         ----------
@@ -34,6 +34,12 @@ class Station:
         self._mac_addr = mac_addr
         self._supp_rates = supp_rates
         self._last_seen = timestamp
+        self._overhead_mcs = overhead_mcs
+        self._overhead_legacy = overhead_legacy
+        self._ampdu_enabled = False
+        self._ampdu_packets = 0
+        self._ampdu_len = 0
+        self._avg_ampdu_len = 0
         self._stats = {}
         self._rssi = 1
         self._rssi_vals = []
@@ -49,6 +55,46 @@ class Station:
     @radio.setter
     def radio(self, radio):
         self._radio = radio
+    
+    @property
+    def ampdu_packets(self) -> int:
+        return self._ampdu_packets
+    
+    @ampdu_packets.setter
+    def ampdu_packets(self, packet_count):
+        self._ampdu_packets = packet_count
+    
+    @property
+    def ampdu_len(self) -> int:
+        return self._ampdu_len
+    
+    @ampdu_len.setter
+    def ampdu_len(self, length):
+        self._ampdu_len = length
+    
+    @property
+    def avg_ampdu_len(self):
+        return self._avg_ampdu_len
+    
+    @avg_ampdu_len.setter
+    def avg_ampdu_len(self, avg_length):
+        self._avg_ampdu_len = avg_length
+    
+    @property
+    def ampdu_enabled(self) -> bool:
+        return self._ampdu_enabled
+    
+    @ampdu_enabled.setter
+    def ampdu_enabled(self, enabled: bool):
+        self._ampdu_enabled = enabled
+    
+    @property
+    def overhead_mcs(self):
+        return self._overhead_mcs
+    
+    @property
+    def overhead_legacy(self):
+        return self._overhead_legacy
 
     @property
     def supp_rates(self) -> list:

--- a/RateMan/rateman/tasks.py
+++ b/RateMan/rateman/tasks.py
@@ -143,7 +143,7 @@ class TaskMan:
                 name=f"collector_{ap.ap_id}",
             )
     
-            if ap.rate_control_alg != "minstrel_ht_kernel_space":
+            if ap.rate_control and ap.rate_control_alg != "minstrel_ht_kernel_space":
                 self.add_task(ap.rate_control(ap, self._loop), name=f"rc_{ap.ap_id}")
 
     async def collect_data(self, ap, reconnect_timeout=10):
@@ -192,7 +192,7 @@ class TaskMan:
                 break
             except (asyncio.TimeoutError, UnicodeError):
                 await asyncio.sleep(0.01)
-            except ConnectionError:
+            except (ConnectionError, TimeoutError):
                 ap.connected = False
                 logging.error(f"Disconnected from {ap.ap_id}")
 

--- a/demo/rateman_refactoring_demo.py
+++ b/demo/rateman_refactoring_demo.py
@@ -10,12 +10,12 @@ import argparse
 import asyncio
 
 
-# Exec: python rateman.py minstrel_ht_user_space AP1:192.168.23.4 AP2:192.46.34.23 -A ../../demo/sample_ap_lists/local_test.csv
+# Exec: python rateman.py minstrel-ht-user-space AP1:192.168.1.1:22 AP2:192.168.200.1:22 -A ../../demo/sample_ap_lists/local_test.csv
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument(
     "algorithm",
     type=str,
-    choices=["minstrel_ht_kernel_space", "minstrel_ht_user_space"],
+    choices=["minstrel_ht_kernel_space", "py_minstrel_ht", "samplerate"],
     default="minstrel_ht_kernel_space",
     help="Rate control algorithm to run.",
 )


### PR DESCRIPTION
- Added “sample rate” to rate control algorithm choice in demo script and renamed “minstrel_ht_user_space” to “py_minstrel_ht”
- Made phy parsing compatible with the new API
- Extended station parsing to also retrieve overhead_legacy and overhead_mcs
- Added ampdu_len and ampdu_packet count for the Station object
- Skips rate control entry function import if the rate control algorithm selection is kernel minstrel ht