### PR TITLE
Change shebang for python scripts in example folder

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import asyncio
 import sys

--- a/examples/rssi_logger.py
+++ b/examples/rssi_logger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
 import asyncio
 import sys


### PR DESCRIPTION
Old shebang runs the global python installation and does not work with virtual environments. Changed shebang such that packages from virtual environment are used when running the example scripts.