### PR TITLE
Fix stats update and power setting

### DIFF
--- a/rateman/parsing.py
+++ b/rateman/parsing.py
@@ -336,18 +336,16 @@ def update_rate_stats_from_txs(ap, fields: list) -> None:
 
     for (cur_stage, next_stage) in pairwise(fields[7:]):
         rate, count, txpwr_idx = parse_mrr_stage(cur_stage)
-        txpwr = supported_txpowers[txpwr_idx] if txpwr_idx else None
         attempts = num_frames * count
         successful = next_stage == ",,"
 
-        sta.update_rate_stats(timestamp, rate, txpwr, attempts, num_ack if successful else 0)
+        sta.update_rate_stats(timestamp, rate, txpwr_idx, attempts, num_ack if successful else 0)
         if successful:
             break
 
     if not successful and ((last_stage := fields[10]) != ",,"):
         rate, count, txpwr_idx = parse_mrr_stage(last_stage)
-        txpwr = supported_txpowers[txpwr_idx] if txpwr_idx else None
-        sta.update_rate_stats(timestamp, rate, txpwr, num_frames * count, num_ack)
+        sta.update_rate_stats(timestamp, rate, txpwr_idx, num_frames * count, num_ack)
 
     sta.update_ampdu(num_frames)
 

--- a/rateman/station.py
+++ b/rateman/station.py
@@ -567,7 +567,7 @@ class Station:
 
         self._validate_txpwrs(pwrs)
 
-        txpwrs = ";".join([f"{self._accesspoint.txpowers(self._radio).index(p):x}" for p in pwrs])
+        txpwrs = ";".join([f"{p:x}" for p in pwrs])
         await self._accesspoint.send(self._radio, f"set_power;{self._mac_addr};{txpwrs}")
 
     async def set_rates_and_power(self, rates: list[int], counts: list[int], pwrs: list[int]):
@@ -594,9 +594,8 @@ class Station:
         self._validate_rates(rates)
         self._validate_txpwrs(pwrs)
 
-        supported_pwrs = self._accesspoint.txpowers(self._radio)
-        txpwrs = [supported_pwrs.index(p) for p in pwrs]
-        mrr = ";".join([f"{r},{c},{p:x}" for ((r, c), p) in zip(zip(rates, counts), txpwrs)])
+        txpwrs = [f"{p:x}" for p in pwrs]
+        mrr = ";".join([f"{r},{c},{p}" for ((r, c), p) in zip(zip(rates, counts), txpwrs)])
         await self._accesspoint.send(self._radio, f"set_rates_power;{self._mac_addr};{mrr}")
 
     async def set_probe_rate(self, rate: str, count: int, txpwr: int = None):


### PR DESCRIPTION
Modified the stats update and setting of transmit power to be compatible with the new parsing of supported transmit power which only consists of ORCA API power indices. 
- Removed the previous mapping of power levels in dBm to ORCA API power indices. 