### PR TITLE
cli: include TPC capabilities in radio dump

### DIFF
--- a/rateman/cli.py
+++ b/rateman/cli.py
@@ -52,16 +52,28 @@ def dump_interfaces(ap, radio):
         print(f"      - {iface}")
         dump_stas(ap, radio, iface)
 
+def format_tpc_info(ap, radio):
+    if ap._radios[radio]["tpc"] is None:
+        return "type=not"
+
+    info = f"type={ap._radios[radio]['tpc']['type']}"
+
+    txpowers = ap.txpowers(radio)
+    info += f", txpowers=(0..{len(txpowers) - 1}) {txpowers}"
+
+    return info
 
 def dump_radios(ap):
     for radio in ap.radios:
         print("""  - %(radio)s
       driver: %(drv)s
       events: %(ev)s
+      tpc: %(tpc)s
       features: %(features)s""" % dict(
                 radio=radio,
                 drv=ap.driver(radio),
                 ev=",".join(ap.enabled_events(radio)),
+                tpc=format_tpc_info(ap, radio),
                 features=", ".join([f"{f}={s}" for f, s in ap._radios[radio]["features"].items()])
             )
         )


### PR DESCRIPTION
I would like to add the TPC capabilities, that Rateman parses from the API output, to the overview that is shown when calling Rateman via its CLI interface with --show-state. This could help to quickly check the TPC support on different nodes via CLI.

Please feel free to suggest or make changes to this.