### PR TITLE
Added changes to improve stability

### DIFF
--- a/rateman/accesspoint.py
+++ b/rateman/accesspoint.py
@@ -411,6 +411,9 @@ class AccessPoint:
         return sta
 
     def update_timestamp(self, timestamp_str):
+        if len(timestamp_str) != 16:
+            return False
+
         try:
             timestamp = int(timestamp_str, 16)
         except Exception:
@@ -420,10 +423,7 @@ class AccessPoint:
             self._latest_timestamp = timestamp
             return True
 
-        if (
-            timestamp > self._latest_timestamp
-            and len(timestamp_str) - len(f"{self._latest_timestamp:x}") <= 1
-        ):
+        if timestamp > self._latest_timestamp:
             self._latest_timestamp = timestamp
             return True
 

--- a/rateman/c_parsing.pyx
+++ b/rateman/c_parsing.pyx
@@ -162,27 +162,31 @@ def parse_txs(const unsigned char[:] data):
     attempts = array.array('i', [0, 0, 0, 0])
     successes = array.array('i', [0, 0, 0, 0])
 
-    if _parse_txs(
-        <const char*> &data[0],
-        phy,
-        &phy_len,
-        &timestamp,
-        mac,
-        &num_frames,
-        rates,
-        txpwrs,
-        attempts,
-        successes
-    ):
-        return None
+    try:
+        if _parse_txs(
+            <const char*> &data[0],
+            phy,
+            &phy_len,
+            &timestamp,
+            mac,
+            &num_frames,
+            rates,
+            txpwrs,
+            attempts,
+            successes
+        ):
+            return None
 
-    return (
-        phy[:phy_len].decode("utf-8", "strict"),
-        timestamp,
-        mac[:17].decode("utf-8", "strict"),
-        num_frames,
-        rates,
-        txpwrs,
-        attempts,
-        successes
-    )
+        return (
+            phy[:phy_len].decode("utf-8", "strict"),
+            timestamp,
+            mac[:17].decode("utf-8", "strict"),
+            num_frames,
+            probe,
+            rates,
+            txpwrs,
+            attempts,
+            successes,
+        )
+    except Exception as e:
+        return None

--- a/rateman/c_sta_rate_stats.pyx
+++ b/rateman/c_sta_rate_stats.pyx
@@ -61,9 +61,15 @@ cdef class StationRateStats:
         cdef int ofs
 
         if self._stats == NULL:
-            return
+            return None
 
         for i in range(len):
+            rate = rates[i]
+            txpwr = txpwrs [i]
+
+            if rate < 0 or rate > self._max_rate_ofs or txpwr > self._max_txpwr_ofs:
+                return None
+
             ofs = self._offset(rates[i], txpwrs[i])
             self._stats[ofs] += attempts[i]
             self._stats[ofs + 1] += successes[i]

--- a/rateman/parsing.py
+++ b/rateman/parsing.py
@@ -163,8 +163,8 @@ async def process_line(ap, line):
 
     if (result := parse_txs(line)) is not None:
         update_rate_stats_from_txs(ap, *result)
-        return None
-
+    elif "txs" in line.decode("utf-8").rstrip():
+        pass
     elif fields := validate_line(ap, line.decode("utf-8").rstrip()):
         match fields[2]:
             case "rxs":
@@ -179,9 +179,6 @@ async def process_line(ap, line):
                 await process_sta_info(ap, fields)
             case "#error":
                 ap.handle_error(fields[3])
-
-        return fields
-
 
 COMMANDS = [
     "start",
@@ -220,13 +217,10 @@ CMD_ECHO_REGEX = re.compile(
 ERROR_REGEX = re.compile(r"\*;0;#error;.*")
 
 
-def validate_line(ap, line: str) -> list:
+def validate_line(ap, line: str):
     fields = line.split(";")
 
     if len(fields) < 3:
-        return None
-
-    if fields[2] == "txs":
         return None
 
     # ensure monotonic timestamps

--- a/rateman/parsing.py
+++ b/rateman/parsing.py
@@ -12,7 +12,7 @@ from .rate_info import *
 
 __all__ = ["process_api", "process_line", "process_header", "parse_sta", "rate_group_and_offset"]
 
-API_VERSION = (3, 0)
+API_VERSION = (3, 0, 0)
 
 
 def vstr(v):
@@ -225,6 +225,9 @@ def validate_line(ap, line: str) -> list:
     fields = line.split(";")
 
     if len(fields) < 3:
+        return None
+
+    if fields[2] == "txs":
         return None
 
     # ensure monotonic timestamps


### PR DESCRIPTION
-Modified the update_timestamp function to address an issue where invalid timestamps were incorrectly causing subsequent valid timestamps to be marked as invalid 
-Updated c_parsing.pyx to add exception handling for the decoding of MACID and PHYID 
-Added a check in _update of c_sta_rate_stats.pyx to prevent the code from breaking due to unsupported rates or power levels in the txs lines 
-Updated API_VERSION to (3,0,0) to align with the three-versioning format in the API